### PR TITLE
Sync scangov.css from components, gitignore local Claude content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ ssl/
 public/data/*
 !public/data/myscangov_homepage_audits.json
 .claude
+docs/plans/
 extra-ca-certs.pem
 scripts/data/scan_*.json
 scripts/data/baseline_domains.json

--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -2081,6 +2081,16 @@ td a:hover .fa-circle-info {
     color: var(--bs-body-color) !important;
 }
 
+.js-sidenav a .fa-circle-question,
+.js-sidenav a:hover .fa-circle-question {
+    color: #97d4ea !important;
+}
+
+.js-sidenav a .fa-circle-info,
+.js-sidenav a:hover .fa-circle-info {
+    color: #b8d293 !important;
+}
+
 .fa-triangle-exclamation {
     color: #f4a0a0;
 }
@@ -2613,6 +2623,16 @@ a .fa-up-right-from-square {
 [data-bs-theme=light] a .fa-circle-info,
 [data-bs-theme=light] a:hover .fa-circle-info {
     color: inherit !important;
+}
+
+[data-bs-theme=light] .js-sidenav a .fa-circle-question,
+[data-bs-theme=light] .js-sidenav a:hover .fa-circle-question {
+    color: #1a6fa0 !important;
+}
+
+[data-bs-theme=light] .js-sidenav a .fa-circle-info,
+[data-bs-theme=light] .js-sidenav a:hover .fa-circle-info {
+    color: #2d7a3a !important;
 }
 
 [data-bs-theme=light] .fa-triangle-exclamation {


### PR DESCRIPTION
Picks up sidebar icon-color fixes and sticky-footer layout from components' canonical scangov.css.