### PR TITLE
Refresh /pulse charts, trim Top issues to 5, add charts to homepage

### DIFF
--- a/_data/dashboard.js
+++ b/_data/dashboard.js
@@ -42,7 +42,7 @@ export default async function () {
         failCount,
       }))
       .sort((a, b) => b.failCount - a.failCount)
-      .slice(0, 10);
+      .slice(0, 5);
   }
   const passRates = {};
   for (const key of indicators) {

--- a/_data/nav.json
+++ b/_data/nav.json
@@ -11,7 +11,7 @@
   },
   {
     "title": "Changelog",
-    "url": "/changelog",
+    "url": "/changelog/",
     "icon": "fa-solid fa-timeline"
   },
   {

--- a/_includes/details.html
+++ b/_includes/details.html
@@ -36,7 +36,13 @@
      the same mono/border-bottom styling as the profile list above.
 #}
 {% if showLastUpdated and not profile %}
+{% set urlParts = page.url.split('/') %}
+{% set filterCounts = { federal: federal, states: states, cities: cities, counties: counties, edu: edu } %}
+{% set siteCount = (filterCounts[urlParts[2]] | length) if filterCounts[urlParts[2]] else (domains | length) %}
 <ul class="small list-unstyled text-body-secondary font-monospace mt-2 mb-0">
+    <li>
+        Sites: {{ siteCount }}
+    </li>
     <li>
         Last scan:
         <span id="updated">{{ updates }}</span>
@@ -65,8 +71,7 @@
     {% endif %}
     {% if site.url == 'https://scangov.org' %}
     <li>
-        Pages: 1 (homepage only)
-        &middot; <a href="https://scangov.com/plans">Get full site scan</a>
+        Pages: 1 (homepage only &middot; <a href="https://scangov.com/plans">get full site scan</a>)
     </li>
     {% elif site.url == 'https://my.scangov.com' %}
     <li>

--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -204,20 +204,23 @@
                     {% if title %}
                     <h1 class="display-5">{{ title }}</h1>
                     {% endif %}
-                    {% if not search %}
+                    {% if not hideDescription %}
                     {% if descriptionHtml %}
-                    <p class="lead fs-5">{{ descriptionHtml | safe }}</p>
+                    <p{% if not plainDescription %} class="lead fs-5"{% endif %}>{{ descriptionHtml | safe }}</p>
                     {% elif description %}
-                    <p class="lead fs-5">{{ description }}</p>
+                    <p{% if not plainDescription %} class="lead fs-5"{% endif %}>{{ description }}</p>
                     {% endif %}
                     {% endif %}
                     {% include "details.html" %}
                     {% if search %}
-                    <div class="row mt-3 mb-0">
+                    <div class="row mt-4 mb-0">
                         <div class="col-12 col-md-6">
                             {% include "search.html" %}
                         </div>
                     </div>
+                    {% endif %}
+                    {% if showActions %}
+                    {% include "actions.html" %}
                     {% endif %}
                 </div>
             </div>

--- a/_includes/rankingtabs.html
+++ b/_includes/rankingtabs.html
@@ -6,6 +6,7 @@
 {% set currentHighlight = " active\" aria-current=\"page" %}
 {% set topLevel = false %}
 {% if page.url.indexOf("/cities/") == -1 and page.url.indexOf("/states/") == -1 and page.url.indexOf("/federal/") == -1
+and page.url.indexOf("/counties/") == -1 and page.url.indexOf("/edu/") == -1
 %}
 {% set topLevel = true %}
 {% endif %}

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,7 +1,7 @@
 <form id="search-form" action="/search/">
-    <label class="form-label visually-hidden" for="search-input">Domain</label>
+    <label class="form-label visually-hidden" for="search-input">Search domains:</label>
     <div class="input-group input-group-lg">
-        <input name="search" type="text" class="form-control shadow" placeholder="ex: ca.gov" id="search-input"
+        <input name="search" type="text" class="form-control shadow" placeholder="search domains" id="search-input"
             autocomplete="off">
         <button type="submit" class="btn btn-primary">Go</button>
     </div>

--- a/content/index.html
+++ b/content/index.html
@@ -4,7 +4,8 @@ layout: layouts/default
 title: Digital experience monitor
 description: A ScanGov project tracking web accessibility, botability, security, and usability.
 descriptionHtml: 'A <a href="https://scangov.com">ScanGov</a> project tracking web <a href="https://scangov.com/accessibility/">accessibility</a>, <a href="https://scangov.com/botability/">botability</a>, <a href="https://scangov.com/security/">security</a>, and <a href="https://scangov.com/usability/">usability</a>.'
-hideDescription: true
+search: true
+plainDescription: true
 showLastUpdated: true
 keywords: government domains, government websites
 ---
@@ -55,6 +56,158 @@ keywords: government domains, government websites
           </div>
         </div>
       {% endfor %}
+    </div>
+
+    <div class="border-top border-bottom pt-4 pb-4 mb-4 mt-4">
+      <h2 class="mb-3">Domains</h2>
+      <p>How scanned domains break down by type and overall grade.</p>
+      <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+      <script>
+        var _isDark;
+        document.addEventListener('DOMContentLoaded', function () {
+          _isDark = document.body.getAttribute('data-bs-theme') !== 'light';
+          Chart.defaults.color = _isDark ? '#fff' : '#000';
+          Chart.defaults.borderColor = _isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+        });
+      </script>
+      <div class="row">
+        <div class="col-12 col-md-6 text-center p-4">
+          <p class="text-center mb-1 small">By domain type</p>
+          <canvas id="domains-chart"></canvas>
+        </div>
+        <div class="col-12 col-md-6 text-center p-4">
+          <p class="text-center mb-1 small">By overall grade</p>
+          <canvas id="grades-dist-chart"></canvas>
+        </div>
+      </div>
+      <script>
+        document.addEventListener('DOMContentLoaded', function () {
+          var donutUrls = ['/rankings/federal/', '/rankings/states/', '/rankings/cities/', '/rankings/counties/', '/rankings/edu/'];
+          var donutEl = document.getElementById('domains-chart');
+          var donutChart = new Chart(donutEl, {
+            type: 'doughnut',
+            data: {
+              labels: ['Federal ({{ federal | length }})', 'States ({{ states | length }})', 'Cities ({{ cities | length }})', 'Counties ({{ counties | length }})', 'Education ({{ edu | length }})'],
+              datasets: [{ data: [{{ federal | length }}, {{ states | length }}, {{ cities | length }}, {{ counties | length }}, {{ edu | length }}], backgroundColor: _isDark ? ['#96abee', '#70e17b', '#ffbc78', '#c5ee93', '#e6a8ff'] : ['#1d4e9a', '#1a7a27', '#a85000', '#4d7c00', '#7b3fa0'], hoverOffset: 4 }]
+            },
+            options: {
+              plugins: {
+                legend: { position: 'top', labels: { padding: 20 } },
+                tooltip: { callbacks: { label: function (ctx) { var t = ctx.dataset.data.reduce(function (a, b) { return a + b; }, 0); var pct = t ? Math.round(ctx.parsed / t * 100) : 0; return ' ' + ctx.parsed + ' (' + pct + '%)'; } } }
+              },
+              onHover: function (e, els) { e.native.target.style.cursor = els.length ? 'pointer' : 'default'; }
+            }
+          });
+          donutEl.addEventListener('click', function (e) {
+            var pts = donutChart.getElementsAtEventForMode(e, 'nearest', { intersect: true }, true);
+            if (pts.length) window.location.href = donutUrls[pts[0].index];
+          });
+
+          var gradeData = {{ dashboard.gradeDistribution | dump | safe }};
+          var gradeEl = document.getElementById('grades-dist-chart');
+          new Chart(gradeEl, {
+            type: 'doughnut',
+            data: {
+              labels: ['A (' + gradeData.A + ')', 'B (' + gradeData.B + ')', 'C (' + gradeData.C + ')', 'D (' + gradeData.D + ')', 'F (' + gradeData.F + ')'],
+              datasets: [{ data: [gradeData.A, gradeData.B, gradeData.C, gradeData.D, gradeData.F], backgroundColor: _isDark ? ['#70e17b', '#c5ee93', '#face00', '#ffbc78', '#e41d3d'] : ['#1a7a27', '#4d7c00', '#8a6600', '#a85000', '#b91c1c'], hoverOffset: 4 }]
+            },
+            options: {
+              plugins: {
+                legend: { position: 'top', labels: { padding: 20 } },
+                tooltip: { callbacks: { label: function (ctx) { var t = ctx.dataset.data.reduce(function (a, b) { return a + b; }, 0); var pct = t ? Math.round(ctx.parsed / t * 100) : 0; return ' ' + ctx.parsed + ' (' + pct + '%)'; } } }
+              }
+            }
+          });
+        });
+      </script>
+    </div>
+
+    <div class="pb-4 mb-4">
+      <h2 class="mb-3">Top issues</h2>
+      <p>Top 5 failing checks per indicator.</p>
+      <div class="row">
+        {% for indicator in site.data %}
+          {% set lower = indicator.toLowerCase() %}
+          {% set catInfo = audits[lower] %}
+          <div class="col-12 col-md-6 mb-4">
+            <h3 class="h5">{{ indicator }}</h3>
+            {% if catInfo %}<p>{{ catInfo.description }}</p>{% endif %}
+            <canvas id="home-chart-{{ lower }}"></canvas>
+            {% if catInfo %}
+            <div class="alert alert-info small mt-2" role="alert">
+              <i class="fa-solid fa-circle-info"></i>
+              {{ catInfo.displayName }}:
+              <a href="https://standards.scangov.org/{{ lower }}/">Standards</a>
+              &middot;
+              <a href="https://standards.scangov.org{{ catInfo.url }}/">Guidance</a>
+              &middot;
+              <a href="{{ site.url }}{{ catInfo.rankingsUrl }}">Project ScanGov</a>
+              &middot;
+              <a href="https://scangov.com{{ catInfo.scangovUrl }}">ScanGov</a>
+            </div>
+            {% endif %}
+          </div>
+        {% endfor %}
+      </div>
+      <script>
+        document.addEventListener('DOMContentLoaded', function () {
+        var chartData = {{ dashboard.charts | dump | safe }};
+        var indicatorColors = {{ dashboard.indicatorColors | dump | safe }};
+        var indicatorColorsLight = {{ dashboard.indicatorColorsLight | dump | safe }};
+        ['accessibility', 'botability', 'security', 'usability'].forEach(function (key) {
+          var data = chartData[key] || [];
+          var urls = data.map(function (d) { return 'https://standards.scangov.org/' + d.attr; });
+          var el = document.getElementById('home-chart-' + key);
+          var barColor = _isDark ? (indicatorColors[key] || '#dee2e6') : (indicatorColorsLight[key] || '#212529');
+          var chart = new Chart(el, {
+            type: 'bar',
+            data: {
+              labels: data.map(function (d) { return d.label; }),
+              datasets: [{ data: data.map(function (d) { return d.failCount; }), backgroundColor: barColor }]
+            },
+            options: {
+              indexAxis: 'y',
+              plugins: { legend: { display: false } },
+              scales: {
+                x: { beginAtZero: true },
+                y: {
+                  afterFit: function (scale) { scale.width = 280; },
+                  ticks: {
+                    callback: function (value) {
+                      var label = this.getLabelForValue(value);
+                      if (!label || label.length <= 30) return label;
+                      var words = label.split(' ');
+                      var lines = [];
+                      var current = '';
+                      words.forEach(function (word) {
+                        var candidate = current ? current + ' ' + word : word;
+                        if (candidate.length > 30) {
+                          if (current) lines.push(current);
+                          current = word;
+                        } else {
+                          current = candidate;
+                        }
+                      });
+                      if (current) lines.push(current);
+                      return lines;
+                    }
+                  }
+                }
+              },
+              onHover: function (event, elements) {
+                event.native.target.style.cursor = elements.length ? 'pointer' : 'default';
+              }
+            }
+          });
+          el.addEventListener('click', function (event) {
+            var points = chart.getElementsAtEventForMode(event, 'nearest', { intersect: true }, true);
+            if (points.length > 0) {
+              window.open(urls[points[0].index], '_blank');
+            }
+          });
+        });
+        });
+      </script>
     </div>
   </div>
 </main>

--- a/content/rankings/index.html
+++ b/content/rankings/index.html
@@ -2,7 +2,7 @@
 home: false
 layout: layouts/default
 title: Rankings
-description: Full rankings of every government website ScanGov tracks.
+description: Full rankings of every website ScanGov tracks.
 keywords: government domains, government websites, rankings
 showLastUpdated: true
 

--- a/content/report/index.html
+++ b/content/report/index.html
@@ -2,47 +2,47 @@
 layout: layouts/page
 permalink: /pulse/
 title: Pulse
-description: The state of federal, state, and local government digital experience.
+description: The state of digital experience.
 showLastUpdated: true
+noBorder: true
+showActions: true
 ---
 
-{% include "actions.html" %}
-
 <div class="border-bottom pb-4 mb-4">
-    <h2 class="mb-3">Domains</h2>
-    <p>How scanned domains break down by type and overall grade.</p>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
-    <script>
+  <h2 class="mb-3">Domains</h2>
+  <p>How scanned domains break down by type and overall grade.</p>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+  <script>
       var _isDark;
       document.addEventListener('DOMContentLoaded', function () {
         _isDark = document.body.getAttribute('data-bs-theme') !== 'light';
         Chart.defaults.color = _isDark ? '#fff' : '#000';
         Chart.defaults.borderColor = _isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
       });
-    </script>
-    <div class="row">
-      <div class="col-12 col-md-5">
-        <p class="text-center mb-1 small">By domain type</p>
-        <canvas id="domains-chart"></canvas>
-      </div>
-      <div class="col-12 col-md-5">
-        <p class="text-center mb-1 small">By overall grade</p>
-        <canvas id="grades-dist-chart"></canvas>
-      </div>
+  </script>
+  <div class="row">
+    <div class="col-12 col-md-6 text-center p-4">
+      <p class="text-center mb-1 small">By domain type</p>
+      <canvas id="domains-chart"></canvas>
     </div>
-    <script>
+    <div class="col-12 col-md-6 text-center p-4">
+      <p class="text-center mb-1 small">By overall grade</p>
+      <canvas id="grades-dist-chart"></canvas>
+    </div>
+  </div>
+  <script>
       document.addEventListener('DOMContentLoaded', function () {
-        var donutUrls = ['/rankings/federal/', '/rankings/states/', '/rankings/cities/'];
+        var donutUrls = ['/rankings/federal/', '/rankings/states/', '/rankings/cities/', '/rankings/counties/', '/rankings/edu/'];
         var donutEl = document.getElementById('domains-chart');
         var donutChart = new Chart(donutEl, {
           type: 'doughnut',
           data: {
-            labels: ['Federal ({{ federal | length }})', 'States ({{ states | length }})', 'Cities ({{ cities | length }})'],
-            datasets: [{ data: [{{ federal | length }}, {{ states | length }}, {{ cities | length }}], backgroundColor: _isDark ? ['#96abee', '#70e17b', '#ffbc78'] : ['#1d4e9a', '#1a7a27', '#a85000'], hoverOffset: 4 }]
+            labels: ['Federal ({{ federal | length }})', 'States ({{ states | length }})', 'Cities ({{ cities | length }})', 'Counties ({{ counties | length }})', 'Education ({{ edu | length }})'],
+            datasets: [{ data: [{{ federal | length }}, {{ states | length }}, {{ cities | length }}, {{ counties | length }}, {{ edu | length }}], backgroundColor: _isDark ? ['#96abee', '#70e17b', '#ffbc78', '#c5ee93', '#e6a8ff'] : ['#1d4e9a', '#1a7a27', '#a85000', '#4d7c00', '#7b3fa0'], hoverOffset: 4 }]
           },
           options: {
             plugins: {
-              legend: { position: 'top' },
+              legend: { position: 'top', labels: { padding: 20 } },
               tooltip: { callbacks: { label: function (ctx) { var t = ctx.dataset.data.reduce(function (a, b) { return a + b; }, 0); var pct = t ? Math.round(ctx.parsed / t * 100) : 0; return ' ' + ctx.parsed + ' (' + pct + '%)'; } } }
             },
             onHover: function (e, els) { e.native.target.style.cursor = els.length ? 'pointer' : 'default'; }
@@ -63,22 +63,22 @@ showLastUpdated: true
           },
           options: {
             plugins: {
-              legend: { position: 'top' },
+              legend: { position: 'top', labels: { padding: 20 } },
               tooltip: { callbacks: { label: function (ctx) { var t = ctx.dataset.data.reduce(function (a, b) { return a + b; }, 0); var pct = t ? Math.round(ctx.parsed / t * 100) : 0; return ' ' + ctx.parsed + ' (' + pct + '%)'; } } }
             }
           }
         });
       });
-    </script>
-  </div>
+  </script>
+</div>
 
-  <div class="border-bottom pb-4 mb-4">
-    <h2 class="mb-3">Grades</h2>
-    <p>Average grades across all scanned domains for each indicator, color-coded by grade.</p>
-    <div class="col-12 col-lg-10">
-      <canvas id="grades-chart"></canvas>
-    </div>
-    <script>
+<div class="border-bottom pb-4 mb-4">
+  <h2 class="mb-3">Grades</h2>
+  <p>Average grades across all scanned domains for each indicator, color-coded by grade.</p>
+  <div class="col-12 col-lg-10">
+    <canvas id="grades-chart"></canvas>
+  </div>
+  <script>
       document.addEventListener('DOMContentLoaded', function () {
         function scoreToGrade(s) {
           if (s >= 90) return 'A';
@@ -127,29 +127,29 @@ showLastUpdated: true
           }
         });
       });
-    </script>
-    <div class="alert alert-info small mt-2" role="alert">
-      Grades
-      {% set infoHref = "https://docs.scangov.org/grades/" %}
-      {% set infoLabel = "Grades" %}
-      {% set infoDescription = "How we calculate letter grades." %}
-      {% include "info-icon.html" %}
-      &middot;
+  </script>
+  <div class="alert alert-info small mt-2" role="alert">
+    Grades
+    {% set infoHref = "https://docs.scangov.org/grades/" %}
+    {% set infoLabel = "Grades" %}
+    {% set infoDescription = "How we calculate letter grades." %}
+    {% include "info-icon.html" %}
+    &middot; 
       Standards
-      {% set infoHref = "https://docs.scangov.org/standards/" %}
-      {% set infoLabel = "Standards" %}
-      {% set infoDescription = "The standards ScanGov checks against." %}
-      {% include "info-icon.html" %}
-    </div>
+    {% set infoHref = "https://docs.scangov.org/standards/" %}
+    {% set infoLabel = "Standards" %}
+    {% set infoDescription = "The standards ScanGov checks against." %}
+    {% include "info-icon.html" %}
   </div>
+</div>
 
-  <div class="border-bottom pb-4 mb-4">
-    <h2 class="mb-3">Scores by indicator</h2>
-    <p>Comparison of average federal, state, and city domains scores across each digital experience indicator.</p>
-    <div class="col-12 col-lg-10">
-      <canvas id="indicator-chart"></canvas>
-    </div>
-    <script>
+<div class="border-bottom pb-4 mb-4">
+  <h2 class="mb-3">Scores by indicator</h2>
+  <p>Comparison of average federal, state, city, county, and education domains scores across each digital experience indicator.</p>
+  <div class="col-12 col-lg-10">
+    <canvas id="indicator-chart"></canvas>
+  </div>
+  <script>
       document.addEventListener('DOMContentLoaded', function () {
         new Chart(document.getElementById('indicator-chart'), {
           type: 'bar',
@@ -185,6 +185,26 @@ showLastUpdated: true
                   {{ cities | specificAverageScore('usability') }}
                 ],
                 backgroundColor: _isDark ? '#ffbc78' : '#a85000'
+              },
+              {
+                label: 'Counties',
+                data: [
+                  {{ counties | specificAverageScore('accessibility') }},
+                  {{ counties | specificAverageScore('botability') }},
+                  {{ counties | specificAverageScore('security') }},
+                  {{ counties | specificAverageScore('usability') }}
+                ],
+                backgroundColor: _isDark ? '#c5ee93' : '#4d7c00'
+              },
+              {
+                label: 'Education',
+                data: [
+                  {{ edu | specificAverageScore('accessibility') }},
+                  {{ edu | specificAverageScore('botability') }},
+                  {{ edu | specificAverageScore('security') }},
+                  {{ edu | specificAverageScore('usability') }}
+                ],
+                backgroundColor: _isDark ? '#e6a8ff' : '#7b3fa0'
               }
             ]
           },
@@ -197,39 +217,42 @@ showLastUpdated: true
           }
         });
       });
-    </script>
-    <div class="alert alert-info small mt-2" role="alert">
-      Scores
-      {% set infoHref = "https://docs.scangov.org/scores/" %}
-      {% set infoLabel = "Scores" %}
-      {% set infoDescription = "How we calculate percentage scores." %}
-      {% include "info-icon.html" %}
-      &middot;
+  </script>
+  <div class="alert alert-info small mt-2" role="alert">
+    Scores
+    {% set infoHref = "https://docs.scangov.org/scores/" %}
+    {% set infoLabel = "Scores" %}
+    {% set infoDescription = "How we calculate percentage scores." %}
+    {% include "info-icon.html" %}
+    &middot; 
       Standards
-      {% set infoHref = "https://docs.scangov.org/standards/" %}
-      {% set infoLabel = "Standards" %}
-      {% set infoDescription = "The standards ScanGov checks against." %}
-      {% include "info-icon.html" %}
-    </div>
+    {% set infoHref = "https://docs.scangov.org/standards/" %}
+    {% set infoLabel = "Standards" %}
+    {% set infoDescription = "The standards ScanGov checks against." %}
+    {% include "info-icon.html" %}
   </div>
+</div>
 
-  <div class="border-bottom pb-4 mb-4">
-    <h2 class="mb-3">States</h2>
-    <p>ScanGov overall score for each state's main website.</p>
-    {% include "report-map.html" %}
-  </div>
+<div class="border-bottom pb-4 mb-4">
+  <h2 class="mb-3">States</h2>
+  <p>ScanGov overall score for each state's main website.</p>
+  {% include "report-map.html" %}
+</div>
 
-  <div class="pb-4 mb-4">
-    <h2 class="mb-3">Top issues</h2>
-    <p>Top 10 failing checks per indicator.</p>
-    <div class="row">
-      {% for indicator in site.data %}
-        {% set lower = indicator.toLowerCase() %}
-        {% set catInfo = audits[lower] %}
-        <div class="col-12 col-lg-10 mb-4">
-          <h3 class="h5">{{ indicator }}</h3>
-          <canvas id="chart-{{ lower }}"></canvas>
-          {% if catInfo %}
+<div class="pb-4 mb-4">
+  <h2 class="mb-3">Top issues</h2>
+  <p>Top 5 failing checks per indicator.</p>
+  <div class="row">
+    {% for indicator in site.data %}
+      {% set lower = indicator.toLowerCase() %}
+      {% set catInfo = audits[lower] %}
+      <div class="col-12 col-lg-10 mb-4">
+        <h3 class="h5">{{ indicator }}</h3>
+        {% if catInfo %}
+          <p>{{ catInfo.description }}</p>
+        {% endif %}
+        <canvas id="chart-{{ lower }}"></canvas>
+        {% if catInfo %}
           <div class="alert alert-info small mt-2" role="alert">
             <i class="fa-solid fa-circle-info"></i>
             {{ catInfo.displayName }}:
@@ -241,11 +264,11 @@ showLastUpdated: true
             &middot;
             <a href="https://scangov.com{{ catInfo.scangovUrl }}">ScanGov</a>
           </div>
-          {% endif %}
-        </div>
-      {% endfor %}
-    </div>
-    <script>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+  <script>
       document.addEventListener('DOMContentLoaded', function () {
       var chartData = {{ dashboard.charts | dump | safe }};
       var indicatorColors = {{ dashboard.indicatorColors | dump | safe }};
@@ -303,5 +326,5 @@ showLastUpdated: true
         });
       });
       });
-    </script>
-  </div>
+  </script>
+</div>

--- a/content/search.html
+++ b/content/search.html
@@ -4,6 +4,7 @@ layout: layouts/default
 title: Search
 description: Search domains tracked by ScanGov.
 keywords: government domains, government websites
+hideDescription: true
 search: true
 ---
 


### PR DESCRIPTION
Adds Counties/Education as their own slices in the domains and scores charts, trims Top issues to the worst 5 checks per topic, and ports the domains donut + Top issues section onto the homepage. Also adds a homepage search box, a Sites count above Last scan, and fixes the rankings category-pill active state and a jumbotron/actions double border on /pulse.