### PR TITLE
Migrate rankings and profile tables to shared tablesort library

### DIFF
--- a/_includes/js.html
+++ b/_includes/js.html
@@ -54,6 +54,8 @@
 </script>
 <script src="{{ site.baseurl }}/assets/bootstrap/js/bootstrap-trimmed.min.js" defer></script>
 <script src="{{ site.baseurl }}/assets/bootstrap/js/bootstrap-tooltip.min.js" defer></script>
+<script src="{{ site.baseurl }}/js/tablesort-vendor.js"></script>
+<script src="{{ site.baseurl }}/js/tablesort-init.js"></script>
 <script>
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
     document.documentElement.setAttribute('data-bs-theme', e.matches ? 'dark' : 'light');

--- a/_includes/profile_table.html
+++ b/_includes/profile_table.html
@@ -1,10 +1,10 @@
 <div class="table-responsive">
-  <table class="table mb-2">
+  <table class="table mb-2" data-sortable>
     <caption class="visually-hidden">Compliance status by standard</caption>
     <thead>
       <tr>
-        <th scope="col" class="sortable" data-col="0">Status <span class="sort-icons"><i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc d-none"></i><i class="fa-solid fa-sort-down sort-desc d-none"></i></span></th>
-        <th scope="col" class="sortable" data-col="1">Standards <span class="sort-icons"><i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc d-none"></i><i class="fa-solid fa-sort-down sort-desc d-none"></i></span></th>
+        <th scope="col" data-sort-default>Status <i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc"></i><i class="fa-solid fa-sort-down sort-desc"></i></th>
+        <th scope="col">Standards <i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc"></i><i class="fa-solid fa-sort-down sort-desc"></i></th>
       </tr>
     </thead>
     <tbody id="table-compliance-{{ scorekey }}">
@@ -56,57 +56,3 @@
   {% set infoDescription = "What each status icon means." %}
   {% include "info-icon.html" %}
 </div>
-<script>
-(function () {
-  var tbody = document.getElementById('table-compliance-{{ scorekey }}');
-  if (!tbody) return;
-  var table = tbody.closest('table');
-  var headers = table.querySelectorAll('th.sortable');
-  var sortState = { col: -1, dir: 'asc' };
-
-  function setIcon(th, dir) {
-    th.querySelector('.sort-neutral').classList.toggle('d-none', dir !== null);
-    th.querySelector('.sort-asc').classList.toggle('d-none', dir !== 'asc');
-    th.querySelector('.sort-desc').classList.toggle('d-none', dir !== 'desc');
-  }
-
-  headers.forEach(function (th) {
-    th.addEventListener('click', function () {
-      var col = parseInt(this.getAttribute('data-col'));
-      if (sortState.col === col) {
-        sortState.dir = sortState.dir === 'asc' ? 'desc' : 'asc';
-      } else {
-        sortState.col = col;
-        sortState.dir = 'asc';
-      }
-      headers.forEach(function (h) { setIcon(h, null); });
-      setIcon(this, sortState.dir);
-
-      var rows = Array.from(tbody.querySelectorAll('tr'));
-      rows.sort(function (a, b) {
-        var aVal = a.cells[col].getAttribute('data-sort') || '';
-        var bVal = b.cells[col].getAttribute('data-sort') || '';
-        if (col === 1) {
-          return sortState.dir === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
-        }
-        return sortState.dir === 'asc'
-          ? parseInt(aVal) - parseInt(bVal)
-          : parseInt(bVal) - parseInt(aVal);
-      });
-      rows.forEach(function (row) { tbody.appendChild(row); });
-    });
-  });
-
-  // Default sort: Status (col 0) ascending, missing/inaccessible first
-  (function () {
-    var rows = Array.from(tbody.querySelectorAll('tr'));
-    rows.sort(function (a, b) {
-      return parseInt(a.cells[0].getAttribute('data-sort') || '0') - parseInt(b.cells[0].getAttribute('data-sort') || '0');
-    });
-    rows.forEach(function (row) { tbody.appendChild(row); });
-    sortState.col = 0;
-    sortState.dir = 'asc';
-    setIcon(headers[0], 'asc');
-  })();
-})();
-</script>

--- a/_includes/rankingheaders.html
+++ b/_includes/rankingheaders.html
@@ -1,6 +1,6 @@
 <tr>
-  <th scope="col" class="rankings-col-rank sortable" data-col="0">Rank <span class="sort-icons"><i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc d-none"></i><i class="fa-solid fa-sort-down sort-desc d-none"></i></span></th>
-  <th scope="col" class="rankings-col-site sortable" data-col="1">Site <span class="sort-icons"><i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc d-none"></i><i class="fa-solid fa-sort-down sort-desc d-none"></i></span></th>
-  <th scope="col" class="rankings-col-status sortable" data-col="2">Status <span class="sort-icons"><i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc d-none"></i><i class="fa-solid fa-sort-down sort-desc d-none"></i></span></th>
-  <th scope="col" class="rankings-col-grade sortable" data-col="3">Grade <span class="sort-icons"><i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc d-none"></i><i class="fa-solid fa-sort-down sort-desc d-none"></i></span></th>
+  <th scope="col" class="rankings-col-rank">Rank <i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc"></i><i class="fa-solid fa-sort-down sort-desc"></i></th>
+  <th scope="col" class="rankings-col-site">Site <i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc"></i><i class="fa-solid fa-sort-down sort-desc"></i></th>
+  <th scope="col" class="rankings-col-status">Status <i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc"></i><i class="fa-solid fa-sort-down sort-desc"></i></th>
+  <th scope="col" class="rankings-col-grade">Grade <i class="fa-solid fa-sort sort-neutral"></i><i class="fa-solid fa-sort-up sort-asc"></i><i class="fa-solid fa-sort-down sort-desc"></i></th>
 </tr>

--- a/_includes/rankingtable.html
+++ b/_includes/rankingtable.html
@@ -1,6 +1,6 @@
 <tr>
   <td data-sort="{{ d.rankingPosition }}">{{ d.rankingPosition }}</td>
-  <td>
+  <td data-sort="{{ d.urlkey }}">
         <a href="/profile/{{d.urlkey | slugify }}/{% if specificAttribute %}details/?attr={{ specificAttribute }}{% else %}overall/{% endif %}">{{ d.urlkey }}</a>
     <br>
     <a class="small text-muted" href="/org/{{ d.name | slugify }}/">{{ d.name }}</a>

--- a/_includes/sortcontent.html
+++ b/_includes/sortcontent.html
@@ -8,7 +8,7 @@
     <div class="row">
       <div class="col-12">
         <div class="table-responsive">
-          <table class="table rankings-table">
+          <table class="table rankings-table"{% if currentsort %} data-sortable{% endif %}>
             <caption class="visually-hidden">Site rankings</caption>
             <thead>
               {% include "rankingheaders.html" %}
@@ -87,46 +87,24 @@
     </div>
   </div>
 </main>
+{% if not currentsort %}
 <script>
 (function () {
   var ATTR = '{{ specificAttribute }}';
-  var PAGE_URL = '{{ page.url }}';
-  var isSubset = /\/(cities|states|federal)\//.test(PAGE_URL);
   var STANDARDS_URLS = {
     {% for catKey, cat in audits %}{% if cat.attributes %}'{{ catKey }}': { {% for attr in cat.attributes %}'{{ attr.key }}': 'https://standards.scangov.org/{{ attr.key }}', {% endfor %} },
     {% endif %}{% endfor %}
   };
 
   var tbody = document.getElementById('table');
-  var headers = document.querySelectorAll('.rankings-table th.sortable');
-  var sortState = { col: -1, dir: 'asc' };
+  var headers = document.querySelectorAll('.rankings-table th');
+  var sortState = { col: -1, dir: 'ascending' };
   var fullData = null;
 
-  function setIcon(th, dir) {
-    th.querySelector('.sort-neutral').classList.toggle('d-none', dir !== null);
-    th.querySelector('.sort-asc').classList.toggle('d-none', dir !== 'asc');
-    th.querySelector('.sort-desc').classList.toggle('d-none', dir !== 'desc');
-  }
-
-  // Per-page sort for subset pages (cities/states/federal)
-  function sortPage(col, dir) {
-    var rows = Array.from(tbody.querySelectorAll('tr'));
-    rows.sort(function (a, b) {
-      if (col === 1) {
-        var aLink = a.cells[1].querySelector('a');
-        var bLink = b.cells[1].querySelector('a');
-        var aVal = aLink ? aLink.textContent : '';
-        var bVal = bLink ? bLink.textContent : '';
-        return dir === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
-      }
-      var aVal = parseFloat(a.cells[col].getAttribute('data-sort') || 0);
-      var bVal = parseFloat(b.cells[col].getAttribute('data-sort') || 0);
-      return dir === 'asc' ? aVal - bVal : bVal - aVal;
-    });
-    rows.forEach(function (row) { tbody.appendChild(row); });
-  }
-
-  // Full-dataset sort helpers
+  // Full-dataset sort helpers - this page fetches and rebuilds every row from a
+  // separate JSON dataset rather than re-sorting rows already in the DOM, so it
+  // can't use the shared tablesort library. It still signals state via aria-sort
+  // like every other sortable table, so the icon CSS stays the same everywhere.
   function slugify(str) {
     return str ? str.toString().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : '';
   }
@@ -198,28 +176,29 @@
   function sortAndRender(col, dir) {
     var sorted = fullData.slice().sort(function (a, b) {
       if (col === 1) {
-        return dir === 'asc'
+        return dir === 'ascending'
           ? a.urlkey.localeCompare(b.urlkey)
           : b.urlkey.localeCompare(a.urlkey);
       }
       var aVal = col === 0 ? a.rankingPosition : scoreOf(a);
       var bVal = col === 0 ? b.rankingPosition : scoreOf(b);
-      return dir === 'asc' ? aVal - bVal : bVal - aVal;
+      return dir === 'ascending' ? aVal - bVal : bVal - aVal;
     });
     tbody.innerHTML = sorted.map(renderRow).join('');
     var pag = document.getElementById('ranking-pagination');
     if (pag) pag.classList.add('d-none');
   }
 
-  async function onSortFull(th, col) {
+  async function onSortFull(th) {
+    var col = th.cellIndex;
     if (sortState.col === col) {
-      sortState.dir = sortState.dir === 'asc' ? 'desc' : 'asc';
+      sortState.dir = sortState.dir === 'ascending' ? 'descending' : 'ascending';
     } else {
       sortState.col = col;
-      sortState.dir = 'asc';
+      sortState.dir = 'ascending';
     }
-    headers.forEach(function (h) { setIcon(h, null); });
-    setIcon(th, sortState.dir);
+    headers.forEach(function (h) { h.removeAttribute('aria-sort'); });
+    th.setAttribute('aria-sort', sortState.dir);
 
     if (!fullData) {
       primeIconCache();
@@ -247,27 +226,9 @@
     sortAndRender(sortState.col, sortState.dir);
   }
 
-  function onSortPage(th, col) {
-    if (sortState.col === col) {
-      sortState.dir = sortState.dir === 'asc' ? 'desc' : 'asc';
-    } else {
-      sortState.col = col;
-      sortState.dir = 'asc';
-    }
-    headers.forEach(function (h) { setIcon(h, null); });
-    setIcon(th, sortState.dir);
-    sortPage(col, sortState.dir);
-  }
-
   headers.forEach(function (th) {
-    th.addEventListener('click', function () {
-      var col = parseInt(this.getAttribute('data-col'));
-      if (isSubset) {
-        onSortPage(this, col);
-      } else {
-        onSortFull(this, col);
-      }
-    });
+    th.addEventListener('click', function () { onSortFull(this); });
   });
 })();
 </script>
+{% endif %}

--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -2817,6 +2817,47 @@ th a:focus i, th a:focus svg {
     text-decoration: none;
 }
 
+/* Sortable tables (tablesort library, public/js/tablesort-vendor.js): the icon is
+   driven entirely by the aria-sort attribute the library sets on the sorted <th> -
+   a plain CSS rule, not a second piece of JS guessing at sort state. */
+table[data-sortable] th[role="columnheader"] {
+    cursor: pointer;
+}
+
+th[aria-sort="ascending"] .fa-sort {
+    --fa: "\f0de" !important;
+}
+
+th[aria-sort="descending"] .fa-sort {
+    --fa: "\f0dd" !important;
+}
+
+/* Same aria-sort-driven icon convention, expressed as three sibling icons instead
+   of one - needed on the Eleventy static sites, where @11ty/font-awesome rewrites
+   every <i class="fa-*"> into an inline SVG <use> sprite at build time. A sprite's
+   shape is fixed by which <symbol> it references, so it can't be repainted via a
+   CSS content/custom-property swap the way a font glyph can; toggling which of
+   three fixed icons is visible works regardless of that rewrite. */
+th .sort-asc,
+th .sort-desc {
+    display: none;
+}
+
+th[aria-sort="ascending"] .sort-neutral,
+th[aria-sort="ascending"] .sort-desc,
+th[aria-sort="descending"] .sort-neutral,
+th[aria-sort="descending"] .sort-asc {
+    display: none;
+}
+
+th[aria-sort="ascending"] .sort-asc {
+    display: inline;
+}
+
+th[aria-sort="descending"] .sort-desc {
+    display: inline;
+}
+
 /* Docs */
 #post h2 {
     margin-top: 2.5rem;

--- a/public/js/tablesort-init.js
+++ b/public/js/tablesort-init.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('table[data-sortable]').forEach(t => new Tablesort(t));
+});

--- a/public/js/tablesort-vendor.js
+++ b/public/js/tablesort-vendor.js
@@ -1,0 +1,320 @@
+/* tristen/tablesort v5.7.1 - https://github.com/tristen/tablesort (MIT) */
+/* Core + number plugin, vendored (not an npm dependency). */
+
+;(function() {
+  function Tablesort(el, options) {
+    if (!(this instanceof Tablesort)) return new Tablesort(el, options);
+
+    if (!el || el.tagName !== 'TABLE') {
+      throw new Error('Element must be a table');
+    }
+    this.init(el, options || {});
+  }
+
+  var sortOptions = [];
+
+  var createEvent = function(name) {
+    var evt;
+
+    if (!window.CustomEvent || typeof window.CustomEvent !== 'function') {
+      evt = document.createEvent('CustomEvent');
+      evt.initCustomEvent(name, false, false, undefined);
+    } else {
+      evt = new CustomEvent(name);
+    }
+
+    return evt;
+  };
+  
+  var getInnerText = function(el, options) {
+    var sortAttribute = options.sortAttribute || 'data-sort';
+    if (el.hasAttribute(sortAttribute)) {
+      return el.getAttribute(sortAttribute);
+    }
+    return el.textContent || el.innerText || '';
+  };
+
+  // Default sort method if no better sort method is found
+  var caseInsensitiveSort = function(a, b) {
+    a = a.trim().toLowerCase();
+    b = b.trim().toLowerCase();
+
+    if (a === b) return 0;
+    if (a < b) return 1;
+
+    return -1;
+  };
+
+  var getCellByKey = function(cells, key) {
+    return [].slice.call(cells).find(function(cell) {
+      return cell.getAttribute('data-sort-column-key') === key;
+    });
+  };
+
+  // Stable sort function
+  // If two elements are equal under the original sort function,
+  // then there relative order is reversed
+  var stabilize = function(sort, antiStabilize) {
+    return function(a, b) {
+      var unstableResult = sort(a.td, b.td);
+
+      if (unstableResult === 0) {
+        if (antiStabilize) return b.index - a.index;
+        return a.index - b.index;
+      }
+
+      return unstableResult;
+    };
+  };
+
+  Tablesort.extend = function(name, pattern, sort) {
+    if (typeof pattern !== 'function' || typeof sort !== 'function') {
+      throw new Error('Pattern and sort must be a function');
+    }
+
+    sortOptions.push({
+      name: name,
+      pattern: pattern,
+      sort: sort
+    });
+  };
+
+  Tablesort.prototype = {
+
+    init: function(el, options) {
+      var that = this,
+          firstRow,
+          defaultSort,
+          i,
+          cell;
+
+      that.table = el;
+      that.thead = false;
+      that.options = options;
+
+      if (el.rows && el.rows.length > 0) {
+        if (el.tHead && el.tHead.rows.length > 0) {
+          for (i = 0; i < el.tHead.rows.length; i++) {
+            if (el.tHead.rows[i].getAttribute('data-sort-method') === 'thead') {
+              firstRow = el.tHead.rows[i];
+              break;
+            }
+          }
+          if (!firstRow) {
+            firstRow = el.tHead.rows[el.tHead.rows.length - 1];
+          }
+          that.thead = true;
+        } else {
+          firstRow = el.rows[0];
+        }
+      }
+
+      if (!firstRow) return;
+
+      var onClick = function() {
+        if (that.current && that.current !== this) {
+          that.current.removeAttribute('aria-sort');
+        }
+
+        that.current = this;
+        that.sortTable(this);
+      };
+
+      // Assume first row is the header and attach a click handler to each.
+      for (i = 0; i < firstRow.cells.length; i++) {
+        cell = firstRow.cells[i];
+        cell.setAttribute('role','columnheader');
+        if (cell.getAttribute('data-sort-method') !== 'none') {
+          cell.tabIndex = 0;
+          cell.addEventListener('click', onClick, false);
+
+          cell.addEventListener('keydown', function (event) {
+            if (event.key === "Enter") {
+                event.preventDefault();
+                onClick.call(this);
+            }
+          });
+
+          if (cell.getAttribute('data-sort-default') !== null) {
+            defaultSort = cell;
+          }
+        }
+      }
+
+      if (defaultSort) {
+        that.current = defaultSort;
+        that.sortTable(defaultSort);
+      }
+    },
+
+    sortTable: function(header, update) {
+      var that = this,
+          columnKey = header.getAttribute('data-sort-column-key'),
+          column = header.cellIndex,
+          sortFunction = caseInsensitiveSort,
+          item = '',
+          items = [],
+          i = that.thead ? 0 : 1,
+          sortMethod = header.getAttribute('data-sort-method'),
+          sortReverse = header.hasAttribute('data-sort-reverse'),
+          sortOrder = header.getAttribute('aria-sort');
+
+      that.table.dispatchEvent(createEvent('beforeSort'));
+
+      // If updating an existing sort, direction should remain unchanged.
+      if (!update) {
+        if (sortOrder === 'ascending') {
+          sortOrder = 'descending';
+        } else if (sortOrder === 'descending') {
+          sortOrder = 'ascending';
+        } else {
+          sortOrder = !!that.options.descending != sortReverse ? 'descending' : 'ascending';
+        }
+
+        header.setAttribute('aria-sort', sortOrder);
+      }
+
+      if (that.table.rows.length < 2) return;
+
+      // If we force a sort method, it is not necessary to check rows
+      if (!sortMethod) {
+        var cell;
+        while (items.length < 3 && i < that.table.tBodies[0].rows.length) {
+          if(columnKey) {
+            cell = getCellByKey(that.table.tBodies[0].rows[i].cells, columnKey);
+          } else {
+            cell = that.table.tBodies[0].rows[i].cells[column];
+          }
+
+          // Treat missing cells as empty cells
+          item = cell ? getInnerText(cell,that.options) : "";
+
+          item = item.trim();
+
+          if (item.length > 0) {
+            items.push(item);
+          }
+
+          i++;
+        }
+
+        if (!items) return;
+      }
+
+      for (i = 0; i < sortOptions.length; i++) {
+        item = sortOptions[i];
+
+        if (sortMethod) {
+          if (item.name === sortMethod) {
+            sortFunction = item.sort;
+            break;
+          }
+        } else if (items.every(item.pattern)) {
+          sortFunction = item.sort;
+          break;
+        }
+      }
+
+      that.col = column;
+
+      for (i = 0; i < that.table.tBodies.length; i++) {
+        var newRows = [],
+            noSorts = {},
+            j,
+            totalRows = 0,
+            noSortsSoFar = 0;
+
+        if (that.table.tBodies[i].rows.length < 2) continue;
+
+        for (j = 0; j < that.table.tBodies[i].rows.length; j++) {
+          var cell;
+
+          item = that.table.tBodies[i].rows[j];
+          if (item.getAttribute('data-sort-method') === 'none') {
+            // keep no-sorts in separate list to be able to insert
+            // them back at their original position later
+            noSorts[totalRows] = item;
+          } else {
+            if (columnKey) {
+              cell = getCellByKey(item.cells, columnKey);
+            } else {
+              cell = item.cells[that.col];
+            }
+            // Save the index for stable sorting
+            newRows.push({
+              tr: item,
+              td: cell ? getInnerText(cell,that.options) : '',
+              index: totalRows
+            });
+          }
+          totalRows++;
+        }
+        // Before we append should we reverse the new array or not?
+        // If we reverse, the sort needs to be `anti-stable` so that
+        // the double negatives cancel out
+        if (sortOrder === 'descending') {
+          newRows.sort(stabilize(sortFunction, true));
+        } else {
+          newRows.sort(stabilize(sortFunction, false));
+          newRows.reverse();
+        }
+
+        // append rows that already exist rather than creating new ones
+        for (j = 0; j < totalRows; j++) {
+          if (noSorts[j]) {
+            // We have a no-sort row for this position, insert it here.
+            item = noSorts[j];
+            noSortsSoFar++;
+          } else {
+            item = newRows[j - noSortsSoFar].tr;
+          }
+
+          // appendChild(x) moves x if already present somewhere else in the DOM
+          that.table.tBodies[i].appendChild(item);
+        }
+      }
+
+      that.table.dispatchEvent(createEvent('afterSort'));
+    },
+
+    refresh: function() {
+      if (this.current !== undefined) {
+        this.sortTable(this.current, true);
+      }
+    }
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Tablesort;
+  } else {
+    window.Tablesort = Tablesort;
+  }
+})();
+
+/* tablesort.number.js - number sort plugin */
+(function(){
+  var cleanNumber = function(i) {
+    return i.replace(/[^\-?0-9.]/g, '');
+  },
+
+  compareNumber = function(a, b) {
+    a = parseFloat(a);
+    b = parseFloat(b);
+
+    a = isNaN(a) ? 0 : a;
+    b = isNaN(b) ? 0 : b;
+
+    return a - b;
+  };
+
+  Tablesort.extend('number', function(item) {
+    return item.match(/^[-+]?[£\x24Û¢´€]?\d+\s*([,\.]\d{0,2})/) || // Prefixed currency
+      item.match(/^[-+]?\d+\s*([,\.]\d{0,2})?[£\x24Û¢´€]/) || // Suffixed currency
+      item.match(/^[-+]?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?%?$/); // Number
+  }, function(a, b) {
+    a = cleanNumber(a);
+    b = cleanNumber(b);
+
+    return compareNumber(b, a);
+  });
+}());


### PR DESCRIPTION
Replaces the two bespoke sort/icon scripts (profile_table.html and sortcontent.html's onSortPage mode) with the shared tristen/tablesort library synced from components. sortcontent.html's onSortFull mode (the homepage rankings table) keeps its own JS - it fetches and rebuilds every row from a separate JSON dataset, which a generic table-sort library doesn't do - but now signals sort state via aria-sort directly instead of its own icon-toggle helper, so it shares the same CSS-driven icon as every other sortable table on the site.

Which pages get the library is now decided by the existing `currentsort` template variable (set per-page, empty only on the true homepage) rather than a client-side URL regex - the old regex only matched /cities/, /states/, /federal/ and silently missed /edu/ and /counties/, which have the same pre-rendered data as the other subset pages and now correctly get the lighter, library-driven path too.