### PR TITLE
Upgrade sharp to fix Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
 		"@11ty/is-land": "^4.0.0",
 		"leaflet": "^1.9.4",
 		"purgecss": "^7.0.2"
+	},
+	"overrides": {
+		"sharp": "^0.35.3"
 	}
 }


### PR DESCRIPTION
Add npm override for sharp (^0.35.3) since @11ty/eleventy-img still caps its own range below 0.34.0.