### PR TITLE
Fix npm dependency vulnerabilities via package.json overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
 		"purgecss": "^7.0.2"
 	},
 	"overrides": {
-		"sharp": "^0.35.3"
+		"sharp": "^0.35.3",
+		"brace-expansion": "^1.1.18",
+		"postcss": "^8.5.25"
 	}
 }


### PR DESCRIPTION
package-lock.json is gitignored here, so npm audit fix has nothing to commit. Pin brace-expansion and postcss to their patched versions via overrides instead, so the fix holds regardless of lockfile presence.

Part of ScanGov/scangov-com#193